### PR TITLE
Improve authentication flow

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import {AuthModule} from './core/auth/auth.module';
 import {ImportModule} from './core/import/import.module';
 import {CompanyModule} from './core/company/company.module';
 import {AgentModule} from './core/agent/agent.module';
+import {LoadingPageComponent} from './core/loading/loading-page.component';
 
 @NgModule({
   imports: [
@@ -29,6 +30,7 @@ import {AgentModule} from './core/agent/agent.module';
   declarations: [
     AppComponent,
     ErrorPageComponent,
+    LoadingPageComponent,
   ],
   providers: [
     {

--- a/src/app/common/util/util.ts
+++ b/src/app/common/util/util.ts
@@ -22,22 +22,10 @@ export function getTableauDate(date: moment.Moment): string {
  * @param tag - Tag to get the type of
  */
 export function getTagType(tag: Tag): string {
-
   if (tag.type !== 'int') {
     return tag.type;
   }
-
-  let type = '';
-
-  if (!tag.signed) {
-    type += 'u';
-  }
-
-  type += tag.type;
-
-  type += tag.width;
-
-  return type;
+  return `${!tag.signed ? 'u' : ''}${tag.type}${tag.width}`;
 }
 
 /**

--- a/src/app/core/auth/auth.module.ts
+++ b/src/app/core/auth/auth.module.ts
@@ -3,20 +3,28 @@ import {CommonModule} from '@angular/common';
 import {LoginComponent} from './login-page/login/login.component';
 import {LoginPageComponent} from './login-page/login-page.component';
 import {AppThemeModule} from '../theme/app-theme.module';
-import {FormsModule} from '@angular/forms';
+import {ReactiveFormsModule} from '@angular/forms';
 import {AuthGuard} from './auth.guard';
 import {AuthService} from './auth.service';
 import {LoggedinGuard} from './loggedin.guard';
+import {EmailInputComponent} from './login-page/login/email-input/email-input.component';
+import {PasswordInputComponent} from './login-page/login/password-input/password-input.component';
+import {OtpDialogComponent} from './login-page/login/otp/otp-dialog/otp-dialog.component';
+import {OtpInputComponent} from './login-page/login/otp/otp-dialog/otp-input/otp-input.component';
 
 @NgModule({
   imports: [
     CommonModule,
-    FormsModule,
+    ReactiveFormsModule,
     AppThemeModule
   ],
   declarations: [
     LoginComponent,
     LoginPageComponent,
+    EmailInputComponent,
+    PasswordInputComponent,
+    OtpDialogComponent,
+    OtpInputComponent,
   ],
   exports: [
     LoginPageComponent,

--- a/src/app/core/auth/login-page/login/email-input/email-input.component.html
+++ b/src/app/core/auth/login-page/login/email-input/email-input.component.html
@@ -1,0 +1,14 @@
+<ng-container [formGroup]="parentForm">
+  <mdl-textfield
+    type="text"
+    id="emailInput"
+    name="email"
+    label="Email"
+    autocomplete="email"
+    error-msg="Please enter a valid email"
+    floating-label
+    autofocus
+    [class.is-invalid]="f['email'].errors && (f['email'].dirty || f['email'].touched)"
+    [formControlName]="'email'">
+  </mdl-textfield>
+</ng-container>

--- a/src/app/core/auth/login-page/login/email-input/email-input.component.ts
+++ b/src/app/core/auth/login-page/login/email-input/email-input.component.ts
@@ -1,0 +1,22 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {FormGroup} from '@angular/forms';
+
+@Component({
+  selector: 'ix-email-input',
+  templateUrl: './email-input.component.html',
+  styleUrls: ['./email-input.component.css']
+})
+export class EmailInputComponent implements OnInit {
+
+  @Input() parentForm: FormGroup;
+
+  get f() {
+    return this.parentForm.controls;
+  }
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+}

--- a/src/app/core/auth/login-page/login/login.component.html
+++ b/src/app/core/auth/login-page/login/login.component.html
@@ -1,4 +1,4 @@
-<form (ngSubmit)="submitLogin()" #loginForm="ngForm">
+<form (ngSubmit)="submitLogin()" [formGroup]="loginForm">
   <mdl-card mdl-shadow="2">
     <mdl-progress
       [indeterminate]="true"
@@ -8,35 +8,13 @@
       <img src="assets/img/logo.png" alt="IXON Logo" class="logo">
     </mdl-card-title>
     <mdl-card-supporting-text>
-      <mdl-textfield
-        type="text"
-        id="emailInput"
-        name="email"
-        label="Email"
-        autocomplete="email"
-        error-msg="Please enter a valid email"
-        floating-label
-        autofocus
-        required
-        email
-        #emailInput="ngModel"
-        [disabled]="isLoading"
-        [class.is-invalid]="emailInput.errors && (emailInput.dirty || emailInput.touched)"
-        [(ngModel)]="model.email"></mdl-textfield>
+      <ix-email-input
+        [parentForm]="loginForm">
+      </ix-email-input>
       <br>
-      <mdl-textfield
-        type="password"
-        id="passwordInput"
-        name="password"
-        label="Password"
-        autocomplete="current-password"
-        error-msg="Please enter your password"
-        floating-label
-        required
-        #passwordInput="ngModel"
-        [disabled]="isLoading"
-        [class.is-invalid]="passwordInput.errors && (passwordInput.dirty || passwordInput.touched)"
-        [(ngModel)]="model.password"></mdl-textfield>
+      <ix-password-input
+        [parentForm]="loginForm">
+      </ix-password-input>
     </mdl-card-supporting-text>
     <mdl-card-actions mdl-card-border>
       <div>
@@ -45,46 +23,15 @@
           mdl-button
           mdl-colored
           mdl-ripple
-          [disabled]="!loginForm.form.valid || isLoading">
+          [disabled]="!loginForm.valid || isLoading">
           Login
         </button>
       </div>
     </mdl-card-actions>
   </mdl-card>
 </form>
-<mdl-dialog
+<ix-otp-dialog
   #otpDialog
-  [mdl-dialog-config]="{
-  styles:{'width': '25rem'},
-  isModal:true,
-  animate: false,
-  enterTransitionDuration: 400,
-  leaveTransitionDuration: 400}">
-  <h3 class="mdl-dialog__title">One-time password</h3>
-  <form (ngSubmit)="submitLogin()" #otpForm="ngForm">
-    <div class="mdl-dialog__content">
-      <mdl-textfield
-        id="otpInput"
-        name="otp"
-        label="One-time password"
-        error-msg="Please enter a valid one-time password"
-        floating-label
-        maxlength="6"
-        pattern="^[0-9]{6}$"
-        #otpInput="ngModel"
-        required
-        autofocus
-        [class.is-invalid]="otpInput.errors && (otpInput.dirty || otpInput.touched)"
-        [(ngModel)]="model.otp"></mdl-textfield>
-    </div>
-    <div class="mdl-dialog__actions">
-      <button
-        type="submit"
-        mdl-button
-        mdl-colored
-        mdl-ripple
-        [disabled]="!otpForm.form.valid">Submit
-      </button>
-    </div>
-  </form>
-</mdl-dialog>
+  (submit)="submitLogin()"
+  [formGroup]="loginForm">
+</ix-otp-dialog>

--- a/src/app/core/auth/login-page/login/login.component.ts
+++ b/src/app/core/auth/login-page/login/login.component.ts
@@ -62,7 +62,7 @@ export class LoginComponent implements OnInit {
       // We logged in successfully, redirect to import page
       this.snackbar.showToast('Successfully logged in', 3000);
 
-      this.router.navigate(['/']);
+      this.router.navigate(['/import']);
       this.isLoading = false;
     }
   }

--- a/src/app/core/auth/login-page/login/login.component.ts
+++ b/src/app/core/auth/login-page/login/login.component.ts
@@ -1,12 +1,13 @@
-import {Component, ViewChild} from '@angular/core';
-import {LoginDetails} from './logindetails';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {AuthService} from '../../auth.service';
 import {Router} from '@angular/router';
 import {flatMap} from 'rxjs/operators';
 import {InitService} from '../../../init/init.service';
-import {MdlDialogComponent, MdlSnackbarService} from '@angular-mdl/core';
+import {MdlSnackbarService} from '@angular-mdl/core';
 import {HttpErrorResponse} from '@angular/common/http';
-import {UNAUTHORIZED} from 'http-status-codes';
+import {TOO_MANY_REQUESTS, UNAUTHORIZED} from 'http-status-codes';
+import {OtpDialogComponent} from './otp/otp-dialog/otp-dialog.component';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 
 /**
  * Login dialog
@@ -16,12 +17,12 @@ import {UNAUTHORIZED} from 'http-status-codes';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css']
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
 
   /**
    * Reference to the OTP token dialog
    */
-  @ViewChild(MdlDialogComponent) otpDialog: MdlDialogComponent;
+  @ViewChild(OtpDialogComponent) otpDialog: OtpDialogComponent;
 
   /**
    * If currently loading
@@ -29,16 +30,25 @@ export class LoginComponent {
   public isLoading = false;
 
   /**
-   * Model for form
+   * Login dialog formgroup
    */
-  public model = new LoginDetails();
+  public loginForm: FormGroup;
 
   constructor(
     private readonly initService: InitService,
     private readonly authService: AuthService,
     private readonly router: Router,
-    private readonly snackbar: MdlSnackbarService
+    private readonly snackbar: MdlSnackbarService,
+    private readonly fb: FormBuilder,
   ) {
+  }
+
+  ngOnInit() {
+    this.loginForm = this.fb.group({
+      email: new FormControl('', [Validators.required, Validators.email]),
+      password: new FormControl('', [Validators.required]),
+      otp: new FormControl('')
+    });
   }
 
   /**
@@ -50,6 +60,8 @@ export class LoginComponent {
       tableau.submit();
     } else {
       // We logged in successfully, redirect to import page
+      this.snackbar.showToast('Successfully logged in', 3000);
+
       this.router.navigate(['/']);
       this.isLoading = false;
     }
@@ -60,23 +72,41 @@ export class LoginComponent {
    * @param error - The error in question
    */
   onLoginError(error: HttpErrorResponse) {
+    this.isLoading = false;
     switch (error.status) {
       case UNAUTHORIZED: {
         // The user is unauthorized because they are missing an otp token, show dialog
-        if (error.error.data && error.error.data[0].message === 'One-Time Password required') {
-          this.otpRequired();
+        if (error.error.data) {
+          switch (error.error.data[0].message) {
+            case 'One-Time Password required': {
+              this.otpRequired();
+              break;
+            }
+            case 'One-Time Password failed': {
+              this.otpInvalid();
+              break;
+            }
+            default: {
+              this.wrongCredentials();
+              break;
+            }
+          }
         } else {
           // The user is not using correct credentials
           this.wrongCredentials();
         }
         break;
       }
+      case TOO_MANY_REQUESTS: {
+        this.snackbar.showToast('You have tried to login too many times.', 3000);
+        break;
+      }
       case 0: {
-        this.snackbar.showToast('Could not connect to IXON.');
+        this.snackbar.showToast('Could not connect to IXON.', 3000);
         break;
       }
       default: {
-        this.snackbar.showToast('Something went wrong. Please try again later.');
+        this.snackbar.showToast('Something went wrong. Please try again later.', 3000);
         break;
       }
     }
@@ -93,7 +123,7 @@ export class LoginComponent {
     this.isLoading = true;
 
     // Create access token
-    this.authService.createAccessToken(this.model)
+    this.authService.createAccessToken(this.loginForm.value)
       .pipe(
         flatMap(() => this.initService.initializeAuthenticated()),
       ).subscribe(
@@ -106,17 +136,24 @@ export class LoginComponent {
    * Shows snackbar notification and clears the form
    */
   private wrongCredentials() {
-    this.isLoading = false;
-    this.model.password = '';
-    this.model.otp = undefined;
-    this.snackbar.showToast('Incorrect credentials', 3000);
+    this.loginForm.controls['password'].reset();
+    this.loginForm.controls['otp'].reset();
+    this.snackbar.showToast('Incorrect credentials.', 3000);
   }
 
   /**
    * Opens the OTP dialog
    */
   private otpRequired() {
-    this.isLoading = false;
+    this.otpDialog.show();
+    this.snackbar.showToast('Please enter a one-time password.', 3000);
+  }
+
+  private otpInvalid() {
+    this.snackbar.showToast('The entered one-time password is invalid.', 3000);
+
+    this.loginForm.controls['otp'].reset();
+    this.loginForm.controls['otp'].setErrors({'incorrect': true});
     this.otpDialog.show();
   }
 }

--- a/src/app/core/auth/login-page/login/login.component.ts
+++ b/src/app/core/auth/login-page/login/login.component.ts
@@ -47,7 +47,7 @@ export class LoginComponent implements OnInit {
     this.loginForm = this.fb.group({
       email: new FormControl('', [Validators.required, Validators.email]),
       password: new FormControl('', [Validators.required]),
-      otp: new FormControl('')
+      otp: new FormControl('', [Validators.maxLength(6), Validators.pattern(/^[0-9]{6}$/)])
     });
   }
 

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-dialog.component.html
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-dialog.component.html
@@ -1,0 +1,27 @@
+<mdl-dialog
+  #otpDialog
+  [mdl-dialog-config]="{
+  styles:{'width': '25rem'},
+  isModal:true,
+  animate: false,
+  enterTransitionDuration: 400,
+  leaveTransitionDuration: 400}">
+  <form (ngSubmit)="submitForm()" [formGroup]="formGroup">
+    <h3 class="mdl-dialog__title">One-time password</h3>
+    <div class="mdl-dialog__content">
+      <ix-otp-input
+        [parentForm]="formGroup">
+      </ix-otp-input>
+    </div>
+    <div class="mdl-dialog__actions">
+      <button
+        type="submit"
+        mdl-button
+        mdl-colored
+        mdl-ripple
+        [disabled]="!formGroup.valid">
+        Submit
+      </button>
+    </div>
+  </form>
+</mdl-dialog>

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-dialog.component.ts
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-dialog.component.ts
@@ -1,0 +1,38 @@
+import {Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
+import {MdlDialogComponent} from '@angular-mdl/core';
+import {FormControl, FormGroup, Validators} from '@angular/forms';
+
+@Component({
+  selector: 'ix-otp-dialog',
+  templateUrl: './otp-dialog.component.html',
+  styleUrls: ['./otp-dialog.component.css']
+})
+export class OtpDialogComponent implements OnInit {
+
+  @ViewChild(MdlDialogComponent) otpDialog: MdlDialogComponent;
+
+  @Input() formGroup: FormGroup;
+
+  @Output() submit = new EventEmitter();
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+
+  close() {
+    this.otpDialog.close();
+  }
+
+  show() {
+    const otpControl: FormControl = this.formGroup.controls['otp'] as FormControl;
+    otpControl.setValidators(Validators.compose([otpControl.validator, Validators.required]));
+    otpControl.updateValueAndValidity();
+    this.otpDialog.show();
+  }
+
+  submitForm() {
+    this.submit.emit();
+  }
+}

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
@@ -1,0 +1,14 @@
+<ng-container [formGroup]="parentForm">
+  <mdl-textfield
+    id="otpInput"
+    name="otp"
+    label="One-time Password"
+    error-msg="Please enter a valid one-time password"
+    floating-label
+    maxlength="6"
+    pattern="^[0-9]{6}$"
+    autofocus
+    [class.is-invalid]="f['otp'].errors && (f['otp'].dirty || f['otp'].touched)"
+    [formControlName]="'otp'">
+  </mdl-textfield>
+</ng-container>

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
@@ -5,6 +5,7 @@
     label="One-time Password"
     error-msg="Please enter a valid one-time password"
     floating-label
+    maxlength="6"
     [class.is-invalid]="f['otp'].errors && (f['otp'].dirty || f['otp'].touched)"
     [formControlName]="'otp'">
   </mdl-textfield>

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.html
@@ -5,9 +5,6 @@
     label="One-time Password"
     error-msg="Please enter a valid one-time password"
     floating-label
-    maxlength="6"
-    pattern="^[0-9]{6}$"
-    autofocus
     [class.is-invalid]="f['otp'].errors && (f['otp'].dirty || f['otp'].touched)"
     [formControlName]="'otp'">
   </mdl-textfield>

--- a/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.ts
+++ b/src/app/core/auth/login-page/login/otp/otp-dialog/otp-input/otp-input.component.ts
@@ -1,0 +1,23 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {FormGroup} from '@angular/forms';
+
+@Component({
+  selector: 'ix-otp-input',
+  templateUrl: './otp-input.component.html',
+  styleUrls: ['./otp-input.component.css']
+})
+export class OtpInputComponent implements OnInit {
+
+  @Input() parentForm: FormGroup;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+
+  get f() {
+    return this.parentForm.controls;
+  }
+
+}

--- a/src/app/core/auth/login-page/login/password-input/password-input.component.html
+++ b/src/app/core/auth/login-page/login/password-input/password-input.component.html
@@ -1,0 +1,14 @@
+<ng-container [formGroup]="parentForm">
+  <mdl-textfield
+    type="password"
+    id="passwordInput"
+    name="password"
+    label="Password"
+    autocomplete="current-password"
+    error-msg="Please enter your password"
+    floating-label
+    [class.is-invalid]="f['password'].errors && (f['password'].dirty || f['password'].touched)"
+    [formControlName]="'password'">
+  </mdl-textfield>
+</ng-container>
+

--- a/src/app/core/auth/login-page/login/password-input/password-input.component.ts
+++ b/src/app/core/auth/login-page/login/password-input/password-input.component.ts
@@ -1,0 +1,23 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {FormGroup} from '@angular/forms';
+
+@Component({
+  selector: 'ix-password-input',
+  templateUrl: './password-input.component.html',
+  styleUrls: ['./password-input.component.css']
+})
+export class PasswordInputComponent implements OnInit {
+
+  @Input() parentForm: FormGroup;
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+
+  get f() {
+    return this.parentForm.controls;
+  }
+
+}

--- a/src/app/core/error/error-page/error-page.component.css
+++ b/src/app/core/error/error-page/error-page.component.css
@@ -6,7 +6,7 @@
 
 .errorCard {
   width: 30em;
-  height: 10em;
+  height: 15em;
   position: absolute;
   top: 40%;
   left: 50%;

--- a/src/app/core/error/error-page/error-page.component.html
+++ b/src/app/core/error/error-page/error-page.component.html
@@ -3,6 +3,6 @@
     <h1>Something went wrong :(</h1>
   </mdl-card-title>
   <mdl-card-supporting-text>
-    <p>Could not connect to the IXPlatform.</p>
+    <p>{{message}}</p>
   </mdl-card-supporting-text>
 </mdl-card>

--- a/src/app/core/error/error-page/error-page.component.ts
+++ b/src/app/core/error/error-page/error-page.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {ErrorService} from '../error.service';
 
 @Component({
   selector: 'ix-error-page',
@@ -6,5 +7,13 @@ import {Component} from '@angular/core';
   styleUrls: ['./error-page.component.css']
 })
 export class ErrorPageComponent {
+
+  public message: string;
+
+  constructor(private readonly errorService: ErrorService) {
+    this.errorService.errorMessage.subscribe(newMessage => {
+      this.message = newMessage;
+    });
+  }
 
 }

--- a/src/app/core/error/error-page/error-page.component.ts
+++ b/src/app/core/error/error-page/error-page.component.ts
@@ -11,8 +11,8 @@ export class ErrorPageComponent {
   public message: string;
 
   constructor(private readonly errorService: ErrorService) {
-    this.errorService.errorMessage.subscribe(newMessage => {
-      this.message = newMessage;
+    this.errorService.currentError.subscribe(newError => {
+      this.message = newError.message;
     });
   }
 

--- a/src/app/core/error/error.guard.ts
+++ b/src/app/core/error/error.guard.ts
@@ -1,0 +1,26 @@
+import {Injectable} from '@angular/core';
+import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot} from '@angular/router';
+import {Observable} from 'rxjs';
+import {ErrorService} from './error.service';
+import {AppErrors} from './error';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorGuard implements CanActivate {
+
+  constructor(private readonly errorService: ErrorService, private readonly router: Router) {
+
+  }
+
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    if (this.errorService.currentError.value === AppErrors.NO_ERROR) {
+      this.router.navigate(['/']);
+      return false;
+    } else {
+      return true;
+    }
+  }
+}

--- a/src/app/core/error/error.service.spec.ts
+++ b/src/app/core/error/error.service.spec.ts
@@ -1,0 +1,15 @@
+import {inject, TestBed} from '@angular/core/testing';
+
+import {ErrorService} from './error.service';
+
+describe('ErrorService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ErrorService]
+    });
+  });
+
+  it('should be created', inject([ErrorService], (service: ErrorService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/core/error/error.service.ts
+++ b/src/app/core/error/error.service.ts
@@ -1,19 +1,19 @@
 import {Injectable} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
-import {ErrorMessage} from './messages';
+import {AppError, AppErrors} from './error';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ErrorService {
 
-  public errorMessage = new BehaviorSubject(ErrorMessage.UNKOWN_ERROR);
+  public currentError = new BehaviorSubject(AppErrors.NO_ERROR);
 
   constructor() {
   }
 
-  setErrorMessage(message: ErrorMessage) {
-    this.errorMessage.next(message);
+  setErrorMessage(message: AppError) {
+    this.currentError.next(message);
   }
 
 }

--- a/src/app/core/error/error.service.ts
+++ b/src/app/core/error/error.service.ts
@@ -1,0 +1,19 @@
+import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+import {ErrorMessage} from './messages';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorService {
+
+  public errorMessage = new BehaviorSubject(ErrorMessage.UNKOWN_ERROR);
+
+  constructor() {
+  }
+
+  setErrorMessage(message: ErrorMessage) {
+    this.errorMessage.next(message);
+  }
+
+}

--- a/src/app/core/error/error.ts
+++ b/src/app/core/error/error.ts
@@ -1,0 +1,13 @@
+export class AppError {
+  public message: string;
+
+  constructor(message) {
+    this.message = message;
+  }
+}
+
+export const AppErrors = {
+  NO_ERROR: new AppError('An unkown error occurred.'),
+  API_ERROR: new AppError('Could not connect to the IXPlatform.'),
+  NOT_IN_TABLEAU: new AppError('It seems like IXON Tableau-WDC was not loaded inside Tableau. To use IXON Tableau-WDC, please load it inside the Tableau browser.')
+};

--- a/src/app/core/error/messages.ts
+++ b/src/app/core/error/messages.ts
@@ -1,5 +1,0 @@
-export enum ErrorMessage {
-  UNKOWN_ERROR = 'An unkown error occurred.',
-  API_ERROR = 'Could not connect to the IXPlatform.',
-  NOT_IN_TABLEAU = 'It seems like IXON Tableau-WDC was not loaded inside Tableau. To use IXON Tableau-WDC, please load it inside the Tableau browser.'
-};

--- a/src/app/core/error/messages.ts
+++ b/src/app/core/error/messages.ts
@@ -1,0 +1,5 @@
+export enum ErrorMessage {
+  UNKOWN_ERROR = 'An unkown error occurred.',
+  API_ERROR = 'Could not connect to the IXPlatform.',
+  NOT_IN_TABLEAU = 'It seems like IXON Tableau-WDC was not loaded inside Tableau. To use IXON Tableau-WDC, please load it inside the Tableau browser.'
+};

--- a/src/app/core/init/init.service.ts
+++ b/src/app/core/init/init.service.ts
@@ -11,6 +11,8 @@ import {Observable} from 'rxjs';
 import {CompanyService} from '../company/company.service';
 import {HttpErrorResponse} from '@angular/common/http';
 import {Company} from '../company/company.model';
+import {ErrorService} from '../error/error.service';
+import {ErrorMessage} from '../error/messages';
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +28,8 @@ export class InitService {
     private readonly ixApiService: IXApiService,
     private readonly ixLsiApiService: IXLsiApiService,
     private readonly companyService: CompanyService,
-    private readonly agentService: AgentService
+    private readonly agentService: AgentService,
+    private readonly errorService: ErrorService,
   ) {
   }
 
@@ -72,6 +75,7 @@ export class InitService {
         }
         default: {
           Log.e(this.TAG, 'Unhandled errror response, showing error page');
+          this.errorService.setErrorMessage(ErrorMessage.API_ERROR);
           this.router.navigate(['/error']);
           break;
         }

--- a/src/app/core/init/init.service.ts
+++ b/src/app/core/init/init.service.ts
@@ -12,7 +12,7 @@ import {CompanyService} from '../company/company.service';
 import {HttpErrorResponse} from '@angular/common/http';
 import {Company} from '../company/company.model';
 import {ErrorService} from '../error/error.service';
-import {ErrorMessage} from '../error/messages';
+import {AppErrors} from '../error/error';
 
 @Injectable({
   providedIn: 'root'
@@ -40,6 +40,7 @@ export class InitService {
     let initialization;
     // Enables tagChange detection since we're
     return this.zone.run(() => {
+      this.router.navigate(['/import']);
       // Try load access token from localstorage
       const isLoggedIn = this.authService.loadAccessTokenFromPasswordStorage();
 
@@ -75,7 +76,7 @@ export class InitService {
         }
         default: {
           Log.e(this.TAG, 'Unhandled errror response, showing error page');
-          this.errorService.setErrorMessage(ErrorMessage.API_ERROR);
+          this.errorService.setErrorMessage(AppErrors.API_ERROR);
           this.router.navigate(['/error']);
           break;
         }

--- a/src/app/core/loading/loading-page.component.css
+++ b/src/app/core/loading/loading-page.component.css
@@ -1,0 +1,14 @@
+:host {
+  position: relative;
+  display: block;
+  height: 100%;
+}
+
+.loadingpage_spinner {
+  width: 4em;
+  height: 4em;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: -2em 0 0 -2em;
+}

--- a/src/app/core/loading/loading-page.component.html
+++ b/src/app/core/loading/loading-page.component.html
@@ -1,0 +1,2 @@
+<mdl-spinner single-color active class="loadingpage_spinner">
+</mdl-spinner>

--- a/src/app/core/loading/loading-page.component.ts
+++ b/src/app/core/loading/loading-page.component.ts
@@ -1,0 +1,35 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {MdlSnackbarService} from '@angular-mdl/core';
+import {ErrorService} from '../error/error.service';
+import {AppErrors} from '../error/error';
+import {Router} from '@angular/router';
+
+@Component({
+  selector: 'ix-loading',
+  templateUrl: './loading-page.component.html',
+  styleUrls: ['./loading-page.component.css']
+})
+export class LoadingPageComponent implements OnInit, OnDestroy {
+
+  private loadingTimeout: number;
+
+  constructor(
+    private readonly snackbar: MdlSnackbarService,
+    private readonly error: ErrorService,
+    private readonly router: Router,
+  ) {
+  }
+
+  ngOnInit() {
+    this.loadingTimeout = setTimeout(() => {
+      this.snackbar.showToast('Could not connect to Tableau.', 3000);
+      this.error.setErrorMessage(AppErrors.NOT_IN_TABLEAU);
+      this.router.navigate(['/error']);
+    }, 3000);
+  }
+
+  ngOnDestroy(): void {
+    clearTimeout(this.loadingTimeout);
+  }
+
+}

--- a/src/app/core/router/app-router.module.ts
+++ b/src/app/core/router/app-router.module.ts
@@ -8,10 +8,13 @@ import {ErrorPageComponent} from '../error/error-page/error-page.component';
 import {LoginPageComponent} from '../auth/login-page/login-page.component';
 import {AuthModule} from '../auth/auth.module';
 import {ImportPageComponent} from '../import/import-page.component';
+import {LoadingPageComponent} from '../loading/loading-page.component';
+import {ErrorGuard} from '../error/error.guard';
 
 const routes: Routes = [
-  {path: '', pathMatch: 'full', component: ImportPageComponent, canActivate: [AuthGuard]},
-  {path: 'error', component: ErrorPageComponent},
+  {path: '', pathMatch: 'full', component: LoadingPageComponent},
+  {path: 'import', component: ImportPageComponent, canActivate: [AuthGuard]},
+  {path: 'error', component: ErrorPageComponent, canActivate: [ErrorGuard]},
   {path: 'login', component: LoginPageComponent, canActivate: [LoggedinGuard]}
 ];
 
@@ -26,6 +29,7 @@ const routes: Routes = [
   providers: [
     AuthGuard,
     LoggedinGuard,
+    ErrorGuard,
   ],
   exports: [
     RouterModule

--- a/src/app/core/theme/app-theme.module.ts
+++ b/src/app/core/theme/app-theme.module.ts
@@ -9,6 +9,7 @@ import {
   MdlRippleModule,
   MdlShadowModule,
   MdlSnackbarModule,
+  MdlSpinnerModule,
   MdlTableModule,
   MdlTextFieldModule
 } from '@angular-mdl/core';
@@ -30,6 +31,7 @@ import {MdlPopoverModule} from '@angular-mdl/popover';
     MdlSelectModule,
     MdlCheckboxModule,
     MdlTableModule,
+    MdlSpinnerModule
   ],
   declarations: [],
   exports: [
@@ -46,6 +48,7 @@ import {MdlPopoverModule} from '@angular-mdl/popover';
     MdlTableModule,
     MdlDialogModule,
     MdlTableModule,
+    MdlSpinnerModule
   ]
 })
 export class AppThemeModule {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,10 @@ import {environment} from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
+} else {
+  console.log('%cPlease use "initializeApp()" to initialize the app without running in Tableau.', 'color: red; font-weight: bold;init');
+  window['initializeApp'] = () => window['_wdc']['init'](() => {
+  });
 }
 
 // noinspection TsLint

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -33,6 +33,10 @@ mdl-dialog-host-component {
   display: none; // Disable ripples on table checkboxes
 }
 
+.loadingpage_spinner .mdl-spinner__circle {
+  border-width: 4px !important;
+}
+
 $color-primary: 0, 72, 145;
 $color-primary-dark: 0, 34, 99;
 $color-accent: 79, 218, 255;


### PR DESCRIPTION
This PR improves the authentication flow of Tableau WDC by:

* Rewriting the login form to use formbuilder (reactive forms)

* Trying to detect if loading in Tableau, giving error otherwise

* Detecting when OTP token is wrong and showing the dialog again