### PR TITLE
Add branding support

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import {Component} from '@angular/core';
 import {WdcService} from './core/wdc/wdc.service';
+import {Title} from '@angular/platform-browser';
+import {environment} from '../environments/environment';
 
 /**
  * Base component for the app
@@ -11,8 +13,14 @@ import {WdcService} from './core/wdc/wdc.service';
 })
 export class AppComponent {
   constructor(
-    private readonly wdcService: WdcService
+    private readonly wdcService: WdcService,
+    private readonly titleService: Title,
   ) {
+    this.setTitle(`${environment.brandingName} Web Data Connector`);
     this.wdcService.registerWebDataConnector();
+  }
+
+  public setTitle(newTitle: string) {
+    this.titleService.setTitle(newTitle);
   }
 }

--- a/src/app/common/constants.ts
+++ b/src/app/common/constants.ts
@@ -1,6 +1,8 @@
 /**
  * Standard post aggregator options
  */
+import {environment} from '../../environments/environment';
+
 export const POSTAGGR_OPTIONS = [
   'first', 'last', 'mode', 'count'
 ];
@@ -29,4 +31,4 @@ export const CSV_SEPARATOR = ',';
 /**
  * Name of Tableau WDC Connection
  */
-export const CONNECTION_NAME = 'IXON Tableau WDC';
+export const CONNECTION_NAME = `${environment.brandingName} Tableau WDC`;

--- a/src/app/core/auth/login-page/login/login.component.css
+++ b/src/app/core/auth/login-page/login/login.component.css
@@ -3,7 +3,7 @@
 }
 
 .logo {
-  width: 60%;
+  width: 100%;
 }
 
 mdl-card-title {

--- a/src/app/core/auth/login-page/login/login.component.html
+++ b/src/app/core/auth/login-page/login/login.component.html
@@ -5,7 +5,7 @@
       [ngStyle]="{visibility: isLoading ? 'visible' : 'hidden'}">
     </mdl-progress>
     <mdl-card-title>
-      <img [src]="logo" alt="IXON Logo" class="logo">
+      <img [src]="logo" alt="{{name}} Logo" class="logo">
     </mdl-card-title>
     <mdl-card-supporting-text>
       <ix-email-input

--- a/src/app/core/auth/login-page/login/login.component.html
+++ b/src/app/core/auth/login-page/login/login.component.html
@@ -5,7 +5,7 @@
       [ngStyle]="{visibility: isLoading ? 'visible' : 'hidden'}">
     </mdl-progress>
     <mdl-card-title>
-      <img src="assets/img/logo.png" alt="IXON Logo" class="logo">
+      <img [src]="logo" alt="IXON Logo" class="logo">
     </mdl-card-title>
     <mdl-card-supporting-text>
       <ix-email-input

--- a/src/app/core/auth/login-page/login/login.component.ts
+++ b/src/app/core/auth/login-page/login/login.component.ts
@@ -8,6 +8,7 @@ import {HttpErrorResponse} from '@angular/common/http';
 import {TOO_MANY_REQUESTS, UNAUTHORIZED} from 'http-status-codes';
 import {OtpDialogComponent} from './otp/otp-dialog/otp-dialog.component';
 import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {environment} from '../../../../../environments/environment';
 
 /**
  * Login dialog
@@ -155,5 +156,9 @@ export class LoginComponent implements OnInit {
     this.loginForm.controls['otp'].reset();
     this.loginForm.controls['otp'].setErrors({'incorrect': true});
     this.otpDialog.show();
+  }
+
+  get logo() {
+    return `https://cdn.ixon.cloud/sector-logo/${environment.brandingDomain}.png`;
   }
 }

--- a/src/app/core/auth/login-page/login/login.component.ts
+++ b/src/app/core/auth/login-page/login/login.component.ts
@@ -34,6 +34,7 @@ export class LoginComponent implements OnInit {
    * Login dialog formgroup
    */
   public loginForm: FormGroup;
+  public name = environment.brandingName;
 
   constructor(
     private readonly initService: InitService,
@@ -103,7 +104,7 @@ export class LoginComponent implements OnInit {
         break;
       }
       case 0: {
-        this.snackbar.showToast('Could not connect to IXON.', 3000);
+        this.snackbar.showToast(`Could not connect to ${environment.brandingName}`, 3000);
         break;
       }
       default: {

--- a/src/app/core/error/error.ts
+++ b/src/app/core/error/error.ts
@@ -1,3 +1,5 @@
+import {environment} from '../../../environments/environment';
+
 export class AppError {
   public message: string;
 
@@ -9,5 +11,5 @@ export class AppError {
 export const AppErrors = {
   NO_ERROR: new AppError('An unkown error occurred.'),
   API_ERROR: new AppError('Could not connect to the IXPlatform.'),
-  NOT_IN_TABLEAU: new AppError('It seems like IXON Tableau-WDC was not loaded inside Tableau. To use IXON Tableau-WDC, please load it inside the Tableau browser.')
+  NOT_IN_TABLEAU: new AppError(`It seems like ${environment.brandingName} Tableau-WDC was not loaded inside Tableau. To use ${environment.brandingName} Tableau-WDC, please load it inside the Tableau browser.`)
 };

--- a/src/app/core/wdc/wdc-util.ts
+++ b/src/app/core/wdc/wdc-util.ts
@@ -1,5 +1,6 @@
 import TableInfo = tableau.TableInfo;
 import ColumnInfo = tableau.ColumnInfo;
+import {environment} from '../../../environments/environment';
 
 /**
  * Creates the wdc table schema
@@ -10,7 +11,7 @@ import ColumnInfo = tableau.ColumnInfo;
 export function getWDCTableSchema(tableId: string, agentName: string, cols: ColumnInfo[]): TableInfo {
   return {
     id: tableId,
-    alias: `IXON Data Export for Agent "${agentName}".`,
+    alias: `${environment.brandingName} Data Export for Agent "${agentName}".`,
     columns: cols
   };
 }

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -19,6 +19,12 @@ export const environment = {
   brandingDomain: 'connect.ixon.cloud',
 
   /**
+   * Branding name, used in page title
+   * e.g: "{name} Web Data Connector"
+   */
+  brandingName: 'IXON',
+
+  /**
    * Amount of retries for api discovery
    */
   ixApiDiscoveryRetry: 5,

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -14,6 +14,11 @@ export const environment = {
   ixApiDiscoveryUrl: 'https://api.ixon.net',
 
   /**
+   * Branding domain
+   */
+  brandingDomain: 'connect.ixon.cloud',
+
+  /**
    * Amount of retries for api discovery
    */
   ixApiDiscoveryRetry: 5,

--- a/src/environments/environment.prod.example.ts
+++ b/src/environments/environment.prod.example.ts
@@ -10,9 +10,15 @@ export const environment = {
   ixApiDiscoveryUrl: 'https://api.ixon.net',
 
   /**
-   * Branding url
+   * Branding url, used for logo
    */
   brandingDomain: 'connect.ixon.cloud',
+
+  /**
+   * Branding name, used in page title
+   * e.g: "{name} Web Data Connector"
+   */
+  brandingName: 'IXON',
 
   /**
    * Amount of retries for api discovery

--- a/src/environments/environment.prod.example.ts
+++ b/src/environments/environment.prod.example.ts
@@ -10,6 +10,11 @@ export const environment = {
   ixApiDiscoveryUrl: 'https://api.ixon.net',
 
   /**
+   * Branding url
+   */
+  brandingDomain: 'connect.ixon.cloud',
+
+  /**
    * Amount of retries for api discovery
    */
   ixApiDiscoveryRetry: 5,

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>IXON Web Data Connector</title>
+  <title>Web Data Connector</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
With this PR, Tableau-WDC will use branding-dependent images & titles throughout the app.